### PR TITLE
Extract secret key from Environment Variable

### DIFF
--- a/cloudcv17/config.py
+++ b/cloudcv17/config.py
@@ -8,3 +8,6 @@ DROPBOX_APP_SECRET = ''
 
 # Redis Configuration
 REDIS_HOST = 'redis'
+
+# Secret key for Django settings
+SECRET_KEY = 'xyz-secret-key'

--- a/cloudcv17/settings.py
+++ b/cloudcv17/settings.py
@@ -20,7 +20,7 @@ os.environ['CLOUDCV_ABS_DIR'] = BASE_ABS_DIR
 # See https://docs.djangoproject.com/en/1.6/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '9%$in^gpdaig@v3or_to&_z(=n)3)$f1mr3hf9e#kespy2ajlo'
+SECRET_KEY = config.SECRET_KEY
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Secret Key should be set as an environment variable and then extracted into settings. It should not be specified inside source code.

**This commit might break already installed forks. <del>They must set a `SECRET_KEY` environment variable as the original secret key they had been using.</del>** They must set `SECRET_KEY` inside `cloudcv17/config.py` as the original secret key they had been using.
